### PR TITLE
Add support for reading the MDNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ The series/model of the stove.
 The hostname used during creation of the Stove object.
 #### Stove.stove_ip
 The IP address as reported by the stove.
+#### Stove.stove_mdns
+The MAC address prefixed with "ihs_" as reported by the stove.
 #### Stove.stove_ssid
 The SSID to which the stove is connected.
 

--- a/pystove/pystove.py
+++ b/pystove/pystove.py
@@ -43,6 +43,7 @@ DATA_IP = 'ip'
 DATA_LEVEL = 'level'
 DATA_MAINTENANCE_ALARMS = 'maintenance_alarms'
 DATA_MESSAGE_ID = 'message_id'
+DATA_MDNS = 'mdns'
 DATA_MODE = 'mode'
 DATA_NAME = 'name'
 DATA_NEW_FIREWOOD_ESTIMATE = 'new_fire_wood_estimate'
@@ -195,6 +196,7 @@ class Stove():
         self.name = UNKNOWN
         self.series = UNKNOWN
         self.stove_ip = UNKNOWN
+        self.stove_mdns = UNKNOWN
         self.stove_ssid = UNKNOWN
         self._session = aiohttp.ClientSession(headers=HTTP_HEADERS)
         if not skip_ident:
@@ -382,11 +384,13 @@ class Stove():
             """Get stove name and IP."""
             stove_id = await self._get_json('http://' + self.stove_host
                                             + STOVE_ID_URL)
-            if None in [stove_id.get(DATA_NAME), stove_id.get(DATA_IP)]:
-                _LOGGER.warning("Unable to read stove name and/or IP.")
+            if None in [stove_id.get(DATA_NAME), stove_id.get(DATA_IP), stove_id[DATA_MDNS]]:
+                _LOGGER.warning("Unable to read stove name, IP and/or MDNS.")
                 return
-            self.name = stove_id[DATA_NAME]
+            
+            self.name = stove_id[DATA_NAME]            
             self.stove_ip = stove_id[DATA_IP]
+            self.stove_mdns = stove_id[DATA_MDNS]
 
         async def get_ssid():
             """Get stove SSID."""

--- a/pystove/pystove.py
+++ b/pystove/pystove.py
@@ -380,17 +380,28 @@ class Stove():
     async def _identify(self):
         """Get identification and set the properties on the object."""
 
-        async def get_name_and_ip():
-            """Get stove name and IP."""
+        async def get_identification():
+            """Get stove name, IP and MDNS"""
             stove_id = await self._get_json('http://' + self.stove_host
                                             + STOVE_ID_URL)
-            if None in [stove_id.get(DATA_NAME), stove_id.get(DATA_IP), stove_id[DATA_MDNS]]:
-                _LOGGER.warning("Unable to read stove name, IP and/or MDNS.")
+            if not stove_id:
+                _LOGGER.error("Unable to read stove identity informations.")
                 return
             
-            self.name = stove_id[DATA_NAME]            
-            self.stove_ip = stove_id[DATA_IP]
-            self.stove_mdns = stove_id[DATA_MDNS]
+            if DATA_NAME in stove_id:
+                self.name = stove_id[DATA_NAME]            
+            else:
+                _LOGGER.warning("Unable to read stove name.")
+            
+            if DATA_IP in stove_id:
+                self.stove_ip = stove_id[DATA_IP]
+            else:
+                _LOGGER.warning("Unable to read stove IP.")
+
+            if DATA_MDNS in stove_id:
+                self.stove_mdns = stove_id[DATA_MDNS]
+            else:
+                _LOGGER.warning("Unable to read stove MDNS.")
 
         async def get_ssid():
             """Get stove SSID."""
@@ -429,7 +440,7 @@ class Stove():
                 _LOGGER.warning("Unable to open stove version info file.")
 
         await asyncio.gather(*[
-            get_name_and_ip(),
+            get_identification(),
             get_ssid(),
             get_version_info(),
         ])

--- a/pystove/version.py
+++ b/pystove/version.py
@@ -14,4 +14,4 @@
 # along with pystove.  If not, see <http://www.gnu.org/licenses/>.
 #
 # Copyright 2019 Milan van Nugteren
-__version__ = '0.2a1'
+__version__ = '0.3a1'

--- a/pystove/version.py
+++ b/pystove/version.py
@@ -14,4 +14,4 @@
 # along with pystove.  If not, see <http://www.gnu.org/licenses/>.
 #
 # Copyright 2019 Milan van Nugteren
-__version__ = '0.3a1'
+__version__ = '0.2a1'

--- a/pystove_cli.py
+++ b/pystove_cli.py
@@ -192,6 +192,7 @@ async def run_command(stove_host, command, value, loop):
             print("Model:\t\t{} Series".format(stv.series))
             print("Host:\t\t{}".format(stv.stove_host))
             print("IP:\t\t{}".format(stv.stove_ip))
+            print("MDNS:\t\t{}".format(stv.stove_mdns))
             print("SSID:\t\t{}".format(stv.stove_ssid))
             print("Algo Version:\t{}".format(stv.algo_version))
             print()


### PR DESCRIPTION
For the integration into Home Assistant, entities need to have a unique ID. IP address host or device name are not accepted. The "mdns" field returned by `/esp/get_identification` seams to be the MAC address prefixed with "ihs". MAC addresses are accepted as uniqe IDs.

```json
{
    "ip": "192.168.1.194",
    "name": "MyStove",
    "mdns": "ihs_5aea42b26597"
}
```

```
firmware_version: 3.23.0
algorithm: DS.DSB2.221129
wifi: 12.6.0
remote: 3.6.0
```