### PR TITLE
Fix get_live_data expected data length

### DIFF
--- a/pystove/pystove.py
+++ b/pystove/pystove.py
@@ -288,7 +288,8 @@ class Stove:
             DATA_STOVE_TEMPERATURE: [],
             DATA_OXYGEN_LEVEL: [],
         }
-        for i in range(int(response_length / 8)):
+        number_of_datapoints = int(response_length / 8)
+        for i in range(number_of_datapoints):
             data_out[DATA_STOVE_TEMPERATURE].append(
                 (
                     bin_arr[i * 4] << 4
@@ -300,10 +301,10 @@ class Stove:
             )
             data_out[DATA_OXYGEN_LEVEL].append(
                 (
-                    bin_arr[i * 4 + 480] << 4
-                    | bin_arr[i * 4 + 481] << 0
-                    | bin_arr[i * 4 + 482] << 12
-                    | bin_arr[i * 4 + 483] << 8
+                    bin_arr[(number_of_datapoints + i) * 4 + 0] << 4
+                    | bin_arr[(number_of_datapoints + i) * 4 + 1] << 0
+                    | bin_arr[(number_of_datapoints + i) * 4 + 2] << 12
+                    | bin_arr[(number_of_datapoints + i) * 4 + 3] << 8
                 )
                 / 100
             )

--- a/pystove/pystove.py
+++ b/pystove/pystove.py
@@ -280,14 +280,15 @@ class Stove:
         bin_arr = bytearray(
             await self._get("http://" + self.stove_host + STOVE_LIVE_DATA_URL), "utf-8"
         )
-        if len(bin_arr) != 120:
+        response_length = len(bin_arr)
+        if response_length % 8 != 0:
             _LOGGER.error("get_live_data got unexpected response from stove.")
             return
         data_out = {
             DATA_STOVE_TEMPERATURE: [],
             DATA_OXYGEN_LEVEL: [],
         }
-        for i in range(120):
+        for i in range(int(response_length / 8)):
             data_out[DATA_STOVE_TEMPERATURE].append(
                 (
                     bin_arr[i * 4] << 4


### PR DESCRIPTION
get_live_data expects a certain amount of data points (120).
Every data point consists of 2 values, each 4 bytes long.
Before this PR, we checked that the length of the return data was exactly 120 bytes, which is obviously wrong.
With this PR, we just check that the length is divisible by 8 and dynamically decide where to look for the next data type in case the number of datapoints changes in the future.